### PR TITLE
fix relative file path 

### DIFF
--- a/dagster_quickstart_tests/test_assets.py
+++ b/dagster_quickstart_tests/test_assets.py
@@ -6,8 +6,8 @@ from unittest import mock
 
 
 CONFIG = HNStoriesConfig(
-    hn_top_story_ids_path="dagster_quickstart_tests/hackernews_top_story_ids.json",
-    hn_top_stories_path="dagster_quickstart_tests/hackernews_top_stories.csv",
+    hn_top_story_ids_path="hackernews_top_story_ids.json",
+    hn_top_stories_path="hackernews_top_stories.csv",
 )
 
 
@@ -36,7 +36,7 @@ def test_hackernews_top_stories(mock_get):
 
     materialized_results = hackernews_top_stories(CONFIG)
     assert materialized_results.metadata.get("num_records") == 10
-    os.remove("dagster_quickstart_tests/hackernews_top_stories.csv")
+    os.remove("hackernews_top_stories.csv")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
tests failing because source and destination files were already in current unit test directory. removing directory portion.
